### PR TITLE
Prevent crash when pausing on iOS

### DIFF
--- a/texttospeech.ios.ts
+++ b/texttospeech.ios.ts
@@ -131,6 +131,10 @@ export class TNSTextToSpeech {
   }
 
   public pause(now) {
+    if (!this._speechSynthesizer) {
+      this._speechSynthesizer = AVSpeechSynthesizer.alloc().init();
+      this._speechSynthesizer.delegate = new MySpeechDelegate();
+    }
     this._speechSynthesizer.pauseSpeakingAtBoundary(
       now
         ? AVSpeechBoundary.AVSpeechBoundaryImmediate


### PR DESCRIPTION
Was seeing an error when calling pause on line 134 of texttospeech.ios.ts
the method throws an error that this._speechSynthesizer is undefined. 

I fixed it by re-allocating and initializing the AVSpeechSynthesizer and delegate if so.
It fixed the problem. Not sure if there will be side effects.

Testing on iOS 11.3
tns-core-modules 3.4.1
tns-ios 3.4.1